### PR TITLE
Ping pong using streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+### Description
+Redis server written in rust by following rust standard library. 
+
+![Screenshot](https://avatars.githubusercontent.com/u/1529926?s=200&v=4)
+
+### How to test
+
+* ping
+nc localhost 6379
+ping
++PONG
+

--- a/src/libs/mod.rs
+++ b/src/libs/mod.rs
@@ -1,0 +1,2 @@
+pub mod redis_cmd;
+pub mod stream_handler;

--- a/src/libs/redis_cmd.rs
+++ b/src/libs/redis_cmd.rs
@@ -1,0 +1,27 @@
+use std::str::FromStr;
+
+pub enum RedisCmd {
+  Ping,
+  Unsupported
+}
+
+impl FromStr for RedisCmd {
+  type Err = ();
+  
+  fn from_str(input: &str) -> Result<Self, Self::Err> {
+    match input.to_lowercase().as_str() {
+      "ping\n" => Ok(RedisCmd::Ping),
+      "*1\r\n$4\r\nping\r\n" => Ok(RedisCmd::Ping),
+      _ => Ok(RedisCmd::Unsupported)
+    }
+  }
+}
+
+impl RedisCmd {
+  pub fn response(&self) -> &'static str {
+    match self {
+      Self::Ping => "+PONG\r\n",
+      Self::Unsupported => "unsupported\r\n"
+    }
+  }
+}

--- a/src/libs/stream_handler.rs
+++ b/src/libs/stream_handler.rs
@@ -1,0 +1,49 @@
+use crate::libs::redis_cmd::RedisCmd;
+use std:: {
+  io:: { BufRead, BufReader, BufWriter, Result, Write },
+  net:: { TcpStream },
+  str:: FromStr
+};
+
+pub struct StreamHandler<'a> {
+  reader: BufReader<TcpStream>,
+  writer: BufWriter<&'a TcpStream>
+}
+
+impl<'a> StreamHandler <'a> {
+
+  pub fn new(stream:&'a TcpStream) -> Self {
+    Self {
+      reader: BufReader::new(stream.try_clone().unwrap()),
+      writer: BufWriter::new(stream)
+    }
+  }
+
+  pub fn handle(&mut self) {
+    let input: String = self._read().ok().unwrap();
+    let output: RedisCmd = RedisCmd::from_str(input.as_str()).ok().unwrap();
+
+    self._write(output);
+  }
+
+  pub fn _read(&mut self) -> Result<String> {
+    let received: Vec<u8> = self.reader.fill_buf()?.to_vec();
+
+    self.reader.consume(received.len());
+
+    String::from_utf8(received).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Couldn't parse received string as utf8",
+        )
+    })
+  }
+
+  pub  fn _write(&mut self, cmd: RedisCmd) {
+     let response = cmd.response();
+     self.writer.write_all(response.as_bytes()).unwrap();
+     self.writer.flush().unwrap();
+  }
+
+
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,17 @@
-// Uncomment this block to pass the first stage
-use std::{ io::Write, net::TcpListener};
+use std::{ net::TcpListener};
+mod libs;
+use libs::stream_handler::StreamHandler;
 
 fn main() {
-    // You can use print statements as follows for debugging, they'll be visible when running tests.
     println!("Logs from your program will appear here!");
-
-    // Uncomment this block to pass the first stage
     
     let listener = TcpListener::bind("127.0.0.1:6379").unwrap();
     
     for stream in listener.incoming() {
         match stream {
-            Ok(mut stream) => {
-                println!("accepted new connection");
-                let result = stream.write(b"+PONG\r\n");
-                
-                match result {
-                    Ok(bytes) => println!("bytes written: {bytes}"),
-                    Err(e) => println!("Error writing to stream, {:?}", e)
-                }
-                
+            Ok(stream) => {
+                let mut hander = StreamHandler::new(&stream);
+                hander.handle();
             }
             Err(e) => {
                 println!("error: {}", e);


### PR DESCRIPTION
implement support for the [PING](https://redis.io/commands/ping) command.

Redis clients communicate with Redis servers by sending "[commands](https://redis.io/commands/)". For each command, a Redis server sends a response back to the client. Commands and responses are both encoded using the [Redis protocol](https://redis.io/topics/protocol) (we'll learn more about this in later stages).

[PING](https://redis.io/commands/ping/) is one of the simplest Redis commands. It's used to check whether a Redis server is healthy.

The response for the PING command is +PONG\r\n. This is the string "PONG" encoded using the [Redis protocol](https://redis.io/docs/reference/protocol-spec/).

In this stage, we'll cut corners by ignoring client input and hardcoding +PONG\r\n as a response. We'll learn to parse client input in later stages.