### PR TITLE
devop: respond to multiple pings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@ Redis server written in rust by following rust standard library.
 ### How to test
 
 * ping
+```
 nc localhost 6379
 
 ping
 +PONG
-
+```
+* parallel ping
+```
+echo -e "ping\nping" | redis-cli
+```

--- a/src/libs/redis_cmd.rs
+++ b/src/libs/redis_cmd.rs
@@ -9,11 +9,15 @@ impl FromStr for RedisCmd {
   type Err = ();
   
   fn from_str(input: &str) -> Result<Self, Self::Err> {
-    match input.to_lowercase().as_str() {
-      "ping\n" => Ok(RedisCmd::Ping),
-      "*1\r\n$4\r\nping\r\n" => Ok(RedisCmd::Ping),
-      _ => Ok(RedisCmd::Unsupported)
+    if input.to_lowercase().contains("ping") {
+      Ok(RedisCmd::Ping)
+    } else {
+      Ok(RedisCmd::Unsupported)
     }
+    // match input.to_lowercase().as_str() {
+    //   "ping\n" | "*1\r\n$4\r\nping\r\n" | "ping" => Ok(RedisCmd::Ping),
+    //   _ => Ok(RedisCmd::Unsupported)
+    // }
   }
 }
 
@@ -21,7 +25,7 @@ impl RedisCmd {
   pub fn response(&self) -> &'static str {
     match self {
       Self::Ping => "+PONG\r\n",
-      Self::Unsupported => "unsupported\r\n"
+      Self::Unsupported => ""
     }
   }
 }


### PR DESCRIPTION
Closes #2 
Respond to multiple [PING](https://redis.io/commands/ping) commands sent by the same connection.

A Redis server starts to listen for the next command as soon as it's done responding to the previous one. This allows Redis clients to send multiple commands using the same connection.