### PR TITLE
Support for multiple concurrent clients

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use std::{ net::TcpListener};
 mod libs;
 use libs::stream_handler::StreamHandler;
+use std::thread;
 
 fn main() {
     println!("Logs from your program will appear here!");
@@ -10,8 +11,10 @@ fn main() {
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
-                let mut hander = StreamHandler::new(&stream);
-                hander.handle();
+                thread::spawn(move || {
+                    let mut hander = StreamHandler::new(&stream);
+                    hander.handle();
+                });
             }
             Err(e) => {
                 println!("error: {}", e);


### PR DESCRIPTION
closes #4 

Add support for multiple concurrent clients.

In addition to handling multiple commands from the same client, Redis servers are also designed to handle multiple clients at once.

To implement this, you'll need to either use threads, or, if you're feeling adventurous, an [Event Loop](https://en.wikipedia.org/wiki/Event_loop) (like the official Redis implementation does).

Notes:
Since the tester client only sends the PING command at the moment, it's okay to ignore what the client sends and hardcode a response. We'll get to parsing client input in later stages.