### PR TITLE
[Unit Test] `read_until_crlf`

### DIFF
--- a/src/libs/stream_handler.rs
+++ b/src/libs/stream_handler.rs
@@ -6,7 +6,7 @@ use std:: {
 };
 use std::io::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Message {
   SimpleString(String),
   BulkString(String),
@@ -18,6 +18,18 @@ impl Message {
     match self {
       Message::SimpleString(s) => format!("+{}\r\n", s),
       Message::BulkString(s) => format!("${}\r\n{}\r\n", s.len(), s),
+      Message::Array(arr) => {
+        let mut s = String::from(format!("*{}\r\n", arr.len()));
+
+        arr.iter().for_each(|x| {
+          
+          let sj = x.clone().serialize();
+
+          s.push_str(sj.as_str());
+        });
+
+        return s;
+      }
       _ => panic!("unsupported value for serialize")
     }
   }
@@ -178,7 +190,7 @@ fn parse_message(input: String) -> Result<Message> {
   }
 }
 
-fn read_until_crlf(input: String) -> Option<String> {
+pub fn read_until_crlf(input: String) -> Option<String> {
    let line = input.lines().next();
    
    match line {
@@ -210,12 +222,12 @@ fn parse_array(input: String) -> Result<Message> {
 
     let mut items: Vec<Message> = vec![];
 
-    for (i, line) in input.lines().enumerate() {
-      if i > 0 {
-        let result = parse_message(line.to_string());
+    for (_, line) in input.lines().skip(1).enumerate() {
+      
+      println!("line: {:?}", line);
+      let result = parse_message(line.to_string());
 
-        items.push(result.unwrap());
-      }
+      items.push(result.unwrap());
 
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::{ net::TcpListener};
 mod libs;
+mod tests;
 use libs::stream_handler::StreamHandler;
 use std::thread;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,20 @@
+// You can also organize tests into modules
+mod tests {
+  // Import the test module to access the #[test] attribute
+  use crate::libs::stream_handler::read_until_crlf;
+
+  // Write more tests
+  #[test]
+  fn test_read_until_crlf() {
+    let expected = "2";
+    let input = String::from("*2\r\n$4\r\necho\r\n$3\r\nhey\r\n");
+
+    let output = read_until_crlf(input);
+
+    let output_value = output.unwrap();
+
+    println!("output: {:?}", output_value);
+
+    assert_eq!(output_value, expected);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds unit test for `read_until_crlf` function. 

```
fn read_until_crlf(input: String) -> Option<String> {
   let line = input.lines().next();
   
   match line {
    Some(v) => {
      return Some(v[1..].into());
    },
    None => {
      return None;
    }
   }
}
```

## Testing info
Sample input: `*2\r\n$4\r\necho\r\n$3\r\nhey\r\n`

## Test command

```
cargo test -- --nocapture
```