### PR TITLE
Implement the SET & GET commands

### DIFF
--- a/src/libs/redis_cmd.rs
+++ b/src/libs/redis_cmd.rs
@@ -4,6 +4,8 @@ use std::str::FromStr;
 pub enum RedisCmd {
   Ping,
   Echo,
+  SET,
+  GET,
   Unsupported
 }
 
@@ -15,6 +17,10 @@ impl FromStr for RedisCmd {
       Ok(RedisCmd::Ping)
     } else if input.to_lowercase().contains("echo") {
       Ok(RedisCmd::Echo)
+    } else if input.to_lowercase().contains("get") {
+      Ok(RedisCmd::GET) 
+    } else if input.to_lowercase().contains("set") {
+      Ok(RedisCmd::SET)
     } else {
       Ok(RedisCmd::Unsupported)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,18 +3,26 @@ mod libs;
 mod tests;
 use libs::stream_handler::StreamHandler;
 use std::thread;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
 
 fn main() {
     println!("Logs from your program will appear here!");
-    
+    // create a store here 
+    let hmap: HashMap<String, String> = HashMap::new();
+
+    let store = Arc::new(Mutex::new(hmap));
+
     let listener = TcpListener::bind("127.0.0.1:6379").unwrap();
     
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
+                let store_clone = store.clone();
                 thread::spawn(move || {
                     let mut hander = StreamHandler::new(&stream);
-                    hander.handle();
+                    hander.handle(&store_clone);
                 });
             }
             Err(e) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,4 +31,10 @@ mod tests {
 
     assert_eq!(result.serialize(), input);
   }
+
+  #[test]
+  fn test_get_set_message() {
+    //"*3\r\n$3\r\nSET\r\n$5\r\ngrape\r\n$6\r\nbanana\r\n"
+    unimplemented!();
+  }
 }


### PR DESCRIPTION
add support for the [SET](https://redis.io/commands/set) & [GET](https://redis.io/commands/get) commands.

The SET command is used to set a key to a value. The GET command is used to retrieve the value of a key.

$ redis-cli SET foo bar
OK
$ redis-cli GET foo
bar
The SET command supports a number of extra options like EX (expiry time in seconds), PX (expiry time in milliseconds) and more. We won't cover these extra options in this stage. We'll get to them in later stages.