### PR TITLE
Redis Expiry: `ttl`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,13 @@ use libs::stream_handler::StreamHandler;
 use std::thread;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime};
 
 
 fn main() {
     println!("Logs from your program will appear here!");
     // create a store here 
-    let hmap: HashMap<String, String> = HashMap::new();
+    let hmap: HashMap<String, (String, Option<SystemTime>)> = HashMap::new();
 
     let store = Arc::new(Mutex::new(hmap));
 


### PR DESCRIPTION
add support for setting a key with an expiry.

The expiry for a key can be provided using the "PX" argument to the [SET](https://redis.io/commands/set) command. The expiry is provided in milliseconds.

$ redis-cli SET foo bar px 100 # Sets the key "foo" to "bar" with an expiry of 100 milliseconds
OK
After the key has expired, a GET command for that key should return a "null bulk string" ($-1\r\n).

Tests
The tester will execute your program like this:

$ ./spawn_redis_server.sh
It'll then send a SET command to your server to set a key with an expiry:

$ redis-cli SET foo bar px 100
It'll then immediately send a GET command to retrieve the value:

$ redis-cli GET foo
It'll expect the response to be bar (encoded as a RESP bulk string).

It'll then wait for the key to expire and send another GET command:

$ sleep 0.2 && redis-cli GET foo
It'll expect the response to be $-1\r\n (a "null bulk string").

Notes
Just like command names, command arguments are also case-insensitive. So PX, px and pX are all valid.
The keys, values and expiry times used in the tests will be random, so you won't be able to hardcode a response to pass this stage.