### PR TITLE
Configure listening port

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,16 +6,32 @@ use std::thread;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime};
+use std::env;
 
 
 fn main() {
     println!("Logs from your program will appear here!");
+
+    // env //
+    let args: Vec<String> = env::args().collect();
+    let mut port_num = "6379".to_string();
+
+    if let Some(index) = args.iter().position(|x| x.contains("port")) {
+        if index < args.len() - 1 {
+            port_num = args[index + 1].clone();
+        }
+    }
+
+    let bind_address = format!("127.0.0.1:{port_num}");
+
+    println!("listening on: {}", bind_address);
+
     // create a store here 
     let hmap: HashMap<String, (String, Option<SystemTime>)> = HashMap::new();
 
     let store = Arc::new(Mutex::new(hmap));
 
-    let listener = TcpListener::bind("127.0.0.1:6379").unwrap();
+    let listener = TcpListener::bind(bind_address).unwrap();
     
     for stream in listener.incoming() {
         match stream {


### PR DESCRIPTION
Replication extension!

In this extension, you'll extend your Redis server to support [leader-follower replication](https://redis.io/docs/management/replication/). You'll be able to run multiple Redis servers with one acting as the "master" and the others as "replicas". Changes made to the master will be automatically replicated to replicas.

Since we'll need to run multiple instances of your Redis server at once, we can't run all of them on port 6379.

In this stage, you'll add support for starting the Redis server on a custom port. The port number will be passed to your program via the --port flag.

Tests
The tester will execute your program like this:

./spawn_redis_server.sh --port 6380
It'll then try to connect to your TCP server on the specified port number (6380 in the example above). If the connection succeeds, you'll pass this stage.

Notes
Your program still needs to pass the previous stages, so if --port isn't specified, you should default to port 6379.
The tester will pass a random port number to your program, so you can't hardcode the port number from the example above.
If your repository was created before 5th Oct 2023, it's possible that your ./spawn_redis_server.sh script might not be passing arguments on to your program. You'll need to edit ./spawn_redis_server.sh to fix this, check [this PR](https://github.com/codecrafters-io/build-your-own-redis/pull/89/files) for details.