### PR TITLE
Initial Replication ID and Offset

### DIFF
--- a/src/libs/stream_handler.rs
+++ b/src/libs/stream_handler.rs
@@ -171,8 +171,11 @@ impl<'a> StreamHandler <'a> {
                "role:master" 
             };
             
+            // hardcoded values
+            let replica = "master_replid:8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb";
+            let offset = "master_repl_offset:0";
             
-            self._write(format!("${}\r\n{}\r\n", reply.len(), reply));
+            self._write(format!("${}\r\n{}{}{}\r\n", reply.len() + replica.len() + offset.len(), reply, replica, offset));
           },
           Err(_) => {
             println!("Cannot write anything to output")

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use std::env;
 
 fn main() {
     println!("Logs from your program will appear here!");
-
     // env //
     let args: Vec<String> = env::args().collect();
     let mut port_num = "6379".to_string();


### PR DESCRIPTION
The replication ID and offset
Every Redis master has a replication ID: it is a large pseudo random string. This is set when the master is booted. Every time a master instance restarts from scratch, its replication ID is reset.

Each master also maintains a "replication offset" corresponding to how many bytes of commands have been added to the replication stream. We'll learn more about this offset in later stages. For now, just know that the value starts from 0 when a master is booted and no replicas have connected yet.

In this stage, you'll initialize a replication ID and offset for your master:

The ID can be any pseudo random alphanumeric string of 40 characters.
For the purposes of this challenge, you don't need to actually generate a random string, you can hardcode it instead.
As an example, you can hardcode 8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb as the replication ID.
The offset is to be 0.
These two values should be returned as part of the INFO command output, under the master_replid and master_repl_offset keys respectively.