### PR TITLE
RDB files from config

### DIFF
--- a/src/libs/stream_handler.rs
+++ b/src/libs/stream_handler.rs
@@ -52,7 +52,9 @@ impl<'a> StreamHandler <'a> {
     }
   }
 
-  pub fn handle(&mut self, store: &Arc<Mutex<HashMap<String, (String, Option<SystemTime>)>>>) {
+  pub fn handle(&mut self, store: &Arc<Mutex<HashMap<String, (String, Option<SystemTime>)>>>,
+  config: &Arc<Mutex<HashMap<String, String>>>
+  ) {
     loop {
       let input_value: String = self._read().ok().unwrap();
       

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,13 +13,42 @@ fn main() {
     println!("Logs from your program will appear here!");
     // env //
     let args: Vec<String> = env::args().collect();
+    
     let mut port_num = "6379".to_string();
+    let mut dir = "".to_string();
+    let mut dbfilename = "".to_string();
 
     if let Some(index) = args.iter().position(|x| x.contains("port")) {
         if index < args.len() - 1 {
             port_num = args[index + 1].clone();
         }
     }
+
+    if let Some(index) = args.iter().position(|x| x.contains("dir")) {
+        if index < args.len() - 1 {
+            dir = args[index + 1].clone();
+        }
+    }
+
+    if let Some(index) = args.iter().position(|x| x.contains("dbfilename")) {
+        if index < args.len() - 1 {
+            dbfilename = args[index + 1].clone();
+        }
+    }
+
+    // config handling
+
+    let config = Arc::new(Mutex::new(HashMap::<String, String>::new()));
+
+    config
+    .lock()
+    .unwrap()
+    .insert("dir".to_string(), dir);
+
+    config
+    .lock()
+    .unwrap()
+    .insert("dbfilename".to_string(), dbfilename);
 
     let bind_address = format!("127.0.0.1:{port_num}");
 
@@ -36,9 +65,10 @@ fn main() {
         match stream {
             Ok(stream) => {
                 let store_clone = store.clone();
+                let config_clone = config.clone();
                 thread::spawn(move || {
                     let mut hander = StreamHandler::new(&stream);
-                    hander.handle(&store_clone);
+                    hander.handle(&store_clone, &config_clone);
                 });
             }
             Err(e) => {


### PR DESCRIPTION
### RDB files

An RDB file is a point-in-time snapshot of a Redis dataset. When RDB persistence is enabled, the Redis server syncs its in-memory state with an RDB file, by doing the following:

On startup, the Redis server loads the data from the RDB file.
While running, the Redis server periodically takes new snapshots of the dataset, in order to update the RDB file.