### PR TITLE
Send handshake using replicaof

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-use std::{ net::TcpListener};
+use std::{ net::TcpListener, net::TcpStream, io::{Write} };
 mod libs;
+mod utils;
 mod tests;
 use libs::stream_handler::StreamHandler;
 use std::thread;
@@ -35,6 +36,17 @@ fn main() {
             dbfilename = args[index + 1].clone();
         }
     }
+    // parse replica
+    let _role = if let Some((host, port)) = utils::parser::parse_replica(&args) {
+        let mut stream = TcpStream::connect(format!("{}:{}", host, port))
+        .expect("failed to connect to master server");
+
+        stream.write_all(b"*1\r\n$4\r\nping\r\n").expect("failed to ping master server");
+
+        "slave"
+    } else {
+        "master"
+    };
 
     // config handling
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod parser;

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -1,0 +1,7 @@
+// Return tuple of host and port 
+pub fn parse_replica(args: &[String]) -> Option<(String, u16)> {
+  //format: --replicaof host port
+  args.iter().position(|item| item == "--replicaof").map(|i| {
+    (args.get(i+1).unwrap().clone(), args.get(i+2).unwrap().parse::<u16>().unwrap())
+  })
+}


### PR DESCRIPTION
Handshake
When a replica connects to a master, it needs to go through a handshake process before receiving updates from the master.

There are three parts to this handshake:

The replica sends a PING to the master (This stage)
The replica sends REPLCONF twice to the master (Next stages)
The replica sends PSYNC to the master (Next stages)
We'll learn more about REPLCONF and PSYNC in later stages. For now, we'll focus on the first part of the handshake: sending PING to the master.

