### PR TITLE
Parse single and multiple args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,23 +19,20 @@ fn main() {
     let mut dir = "".to_string();
     let mut dbfilename = "".to_string();
 
-    if let Some(port) = utils::parser::parse_port(&args) {
+    if let Some(port) = utils::parser::parse_single_arg(&args, "--port") {
         port_num = port;
     }
 
-    if let Some(index) = args.iter().position(|x| x.contains("dir")) {
-        if index < args.len() - 1 {
-            dir = args[index + 1].clone();
-        }
+    if let Some(dir_path) = utils::parser::parse_single_arg(&args, "--dir") {
+        dir = dir_path;
     }
 
-    if let Some(index) = args.iter().position(|x| x.contains("dbfilename")) {
-        if index < args.len() - 1 {
-            dbfilename = args[index + 1].clone();
-        }
+    if let Some(db_file_name) = utils::parser::parse_single_arg(&args, "--dbfilename") {
+        dbfilename = db_file_name;
     }
+
     // parse replica
-    let _role = if let Some((host, port)) = utils::parser::parse_replica(&args) {
+    let _role = if let Some((host, port)) = utils::parser::parse_multi_arg(&args, "--replicaof") {
         let mut stream = TcpStream::connect(format!("{}:{}", host, port))
         .expect("failed to connect to master server");
 

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -1,13 +1,13 @@
 // Return tuple of host and port 
-pub fn parse_replica(args: &[String]) -> Option<(String, u16)> {
+pub fn parse_multi_arg(args: &[String], arg_name: &str) -> Option<(String, u16)> {
   //format: --replicaof host port
-  args.iter().position(|item| item == "--replicaof").map(|i| {
+  args.iter().position(|item| item == arg_name).map(|i| {
     (args.get(i+1).unwrap().clone(), args.get(i+2).unwrap().parse::<u16>().unwrap())
   })
 }
 
-pub fn parse_port(args: &[String]) -> Option<String> {
-  args.iter().position(|item| item == "--port").map(|i| {
+pub fn parse_single_arg(args: &[String], arg_name: &str) -> Option<String> {
+  args.iter().position(|item| item == arg_name).map(|i| {
     args.get(i+1).unwrap().clone()
   })
 }


### PR DESCRIPTION
## Description
This pr updates parser methods `parse_single_arg` and `parse_multiple_args` to make it generic.

## Why
No need to make a separate function for parsing for every argument.