### PR TITLE
[RUST] TCP Receive handshake - 1

### DIFF
--- a/src/libs/redis_cmd.rs
+++ b/src/libs/redis_cmd.rs
@@ -8,6 +8,8 @@ pub enum RedisCmd {
   GET,
   Info,
   Config,
+  Replconf,
+  Psync,
   Unsupported
 }
 
@@ -27,6 +29,10 @@ impl FromStr for RedisCmd {
       Ok(RedisCmd::Info)
     } else if input.to_lowercase().contains("config") {
         Ok(RedisCmd::Config)  
+    } else if input.to_lowercase().contains("replconf") {
+        Ok(RedisCmd::Replconf)
+    } else if input.to_lowercase().contains("psync") {
+        Ok(RedisCmd::Psync)
     } else {
       Ok(RedisCmd::Unsupported)
     }

--- a/src/libs/stream_handler.rs
+++ b/src/libs/stream_handler.rs
@@ -182,6 +182,12 @@ impl<'a> StreamHandler <'a> {
           }
         }
        },
+       RedisCmd::Replconf => {
+        self._write("+OK\r\n".to_string());
+       },
+       RedisCmd::Psync => {
+        self._write("+OK\r\n".to_string());
+      },
        RedisCmd::Info => { 
         let response = parse_message(input_value.clone());
         match response {


### PR DESCRIPTION
closes https://github.com/ahsan-javaid/redis-rs/issues/51

As a recap, there are three parts to the handshake:

The master receives a PING from the replica
Your Redis server already supports the PING command, so there's no additional work to do here
The master receives REPLCONF twice from the replica (This stage)
The master receives PSYNC from the replica (Next stage)
In this stage, you'll add support for receiving the REPLCONF command from the replica.

You'll receive REPLCONF twice from the replica. For the purposes of this challenge, you can safely ignore the arguments for both commands and just respond with +OK\r\n ("OK" encoded as a RESP Simple String).