### PR TITLE
[RUST] Empty RDB Transfer

### DIFF
--- a/src/libs/stream_handler.rs
+++ b/src/libs/stream_handler.rs
@@ -188,9 +188,15 @@ impl<'a> StreamHandler <'a> {
         self._write("+OK\r\n".to_string());
        },
        RedisCmd::Psync => {
-        // self._write("+OK\r\n".to_string());
         let r = format!("+FULLRESYNC {} 0\r\n", DEFAULT_MASTER_REPLID);
         self._write(r.to_string());
+
+        // send rdb file
+        let empty_file_payload = hex::decode("524544495330303131fa0972656469732d76657205372e322e30fa0a72656469732d62697473c040fa056374696d65c26d08bc65fa08757365642d6d656dc2b0c41000fa08616f662d62617365c000fff06e3bfec0ff5aa2").unwrap();
+       
+        self.writer.write_all(format!("${}\r\n", empty_file_payload.len()).as_bytes()).unwrap();
+        self.writer.write_all(empty_file_payload.as_slice()).unwrap();
+        self.writer.flush().unwrap();
       },
        RedisCmd::Info => { 
         let response = parse_message(input_value.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,7 @@ fn main() {
             stream.flush();
             
             let _ = stream.read(&mut buffer);
+            // let _ = stream.read(&mut buffer);
         }
         "slave"
     } else {


### PR DESCRIPTION
closes https://github.com/ahsan-javaid/redis-rs/issues/55


In this stage, you'll add support for sending an empty RDB file to the replica. This is part of the "full resynchronization" process.

Full resynchronization
When a replica connects to a master for the first time, it sends a PSYNC ? -1 command. This is the replica's way of telling the master that it doesn't have any data yet, and needs to be fully resynchronized.

The master acknowledges this by sending a FULLRESYNC response to the replica.

After sending the FULLRESYNC response, the master will then send a RDB file of its current state to the replica. The replica is expected to load the file into memory, replacing its current state.

For the purposes of this challenge, you don't have to actually construct an RDB file. We'll assume that the master's database is always empty, and just hardcode an empty RDB file to send to the replica.

You can find the hex representation of an empty RDB file [here](https://github.com/codecrafters-io/redis-tester/blob/main/internal/assets/empty_rdb_hex.md).

The tester will accept any valid RDB file that is empty, you don't need to send the exact file above.

The file is sent using the following format:

$<length_of_file>\r\n<contents_of_file>
(This is similar to how [Bulk Strings](https://redis.io/topics/protocol#resp-bulk-strings) are encoded, but without the trailing \r\n)

Tests
The tester will execute your program like this:

./your_program.sh --port <PORT>
It'll then connect to your TCP server as a replica and execute the following commands:

PING (expecting +PONG\r\n back)
REPLCONF listening-port <PORT> (expecting +OK\r\n back)
REPLCONF capa eof capa psync2 (expecting +OK\r\n back)
PSYNC ? -1 (expecting +FULLRESYNC <REPL_ID> 0\r\n back)
After receiving a response to the last command, the tester will expect to receive an empty RDB file from your server.

Notes
The [RDB file link](https://github.com/codecrafters-io/redis-tester/blob/main/internal/assets/empty_rdb_hex.md) contains hex & base64 representations of the file. You need to decode these into binary contents before sending it to the replica.
The RDB file should be sent like this: $<length>\r\n<contents>
<length> is the length of the file in bytes
<contents> is the contents of the file
Note that this is NOT a RESP bulk string, it doesn't contain a \r\n at the end
If you want to learn more about the RDB file format, read [this blog post](https://rdb.fnordig.de/file_format.html). This challenge has a separate extension dedicated to reading RDB files.